### PR TITLE
Improve auth pages with dystopic theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,13 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Distopic App</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&family=Roboto:wght@400;500&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/auth.css
+++ b/src/auth.css
@@ -1,0 +1,55 @@
+.auth-container {
+  background-color: var(--color-surface);
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
+  width: 100%;
+  max-width: 420px;
+}
+
+.auth-title {
+  margin-bottom: 1.5rem;
+  text-align: center;
+}
+
+.auth-field {
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.auth-field label {
+  margin-bottom: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.auth-field input {
+  padding: 0.5rem;
+  border: 1px solid var(--color-primary);
+  border-radius: 4px;
+  background-color: var(--color-background);
+  color: var(--color-text);
+  transition: border-color 0.2s ease;
+}
+
+.auth-field input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+}
+
+.auth-error {
+  color: #ff6b6b;
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.auth-actions {
+  margin-top: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.auth-actions a {
+  font-size: 0.875rem;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,68 +1,70 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  --color-background: #1b1d1e;
+  --color-surface: #2c2f33;
+  --color-primary: #3f4147;
+  --color-accent: #e91e63;
+  --color-text: #e0e0e0;
+
+  font-family: 'Roboto', sans-serif;
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color-scheme: dark;
+  color: var(--color-text);
+  background-color: var(--color-background);
 
-  font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background-color: var(--color-background);
+  color: var(--color-text);
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Orbitron', sans-serif;
+}
+
+a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
+  border-radius: 6px;
+  border: none;
   padding: 0.6em 1.2em;
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
+  background-color: var(--color-accent);
+  color: #fff;
   cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
+  transition: opacity 0.2s ease;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+button:hover:not(:disabled) {
+  opacity: 0.85;
 }

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,38 +1,69 @@
 import { type FormEvent, useState } from 'react'
 import { supabase } from '../supabaseClient'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
+import '../auth.css'
 
 export default function Login() {
   const navigate = useNavigate()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setError(null)
+
+    const emailRegex = /^\S+@\S+\.\S+$/
+    if (!emailRegex.test(email)) {
+      setError('Correo electrónico inválido')
+      return
+    }
+    if (password.length === 0) {
+      setError('La contraseña es obligatoria')
+      return
+    }
+
+    setLoading(true)
     const { error: signInError } = await supabase.auth.signInWithPassword({ email, password })
     if (signInError) {
       setError(signInError.message)
+      setLoading(false)
       return
     }
+    setLoading(false)
     navigate('/dashboard')
   }
 
   return (
-    <div className="container mt-5">
-      <h2>Login</h2>
-      {error && <div className="alert alert-danger">{error}</div>}
-      <form onSubmit={handleSubmit} className="needs-validation" noValidate>
-        <div className="mb-3">
-          <label className="form-label">Correo</label>
-          <input type="email" className="form-control" value={email} onChange={(e) => setEmail(e.target.value)} required />
+    <div className="auth-container">
+      <h2 className="auth-title">Iniciar Sesión</h2>
+      {error && <div className="auth-error">{error}</div>}
+      <form onSubmit={handleSubmit} noValidate>
+        <div className="auth-field">
+          <label>Correo</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
         </div>
-        <div className="mb-3">
-          <label className="form-label">Contraseña</label>
-          <input type="password" className="form-control" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        <div className="auth-field">
+          <label>Contraseña</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
         </div>
-        <button type="submit" className="btn btn-primary">Entrar</button>
+        <div className="auth-actions">
+          <button type="submit" disabled={loading}>
+            {loading ? 'Entrando...' : 'Iniciar Sesión'}
+          </button>
+          <Link to="/register">Crear cuenta</Link>
+        </div>
       </form>
     </div>
   )

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -1,6 +1,7 @@
 import { type FormEvent, useState } from 'react'
 import { supabase } from '../supabaseClient'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
+import '../auth.css'
 
 export default function Register() {
   const navigate = useNavigate()
@@ -8,19 +9,39 @@ export default function Register() {
   const [password, setPassword] = useState('')
   const [username, setUsername] = useState('')
   const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     setError(null)
+
+    const usernameRegex = /^[a-zA-Z0-9_]{3,}$/
+    const emailRegex = /^\S+@\S+\.\S+$/
+    if (!usernameRegex.test(username)) {
+      setError('Nombre de usuario inválido')
+      return
+    }
+    if (!emailRegex.test(email)) {
+      setError('Correo electrónico inválido')
+      return
+    }
+    if (password.length < 6) {
+      setError('La contraseña debe tener al menos 6 caracteres')
+      return
+    }
+
+    setLoading(true)
     const { data, error: signUpError } = await supabase.auth.signUp({ email, password })
     if (signUpError || !data.user) {
       setError(signUpError?.message ?? 'Error registering')
+      setLoading(false)
       return
     }
     const userId = data.user.id
     const { error: usuarioError } = await supabase.from('usuarios').insert({ id: userId, nombre: username })
     if (usuarioError) {
       setError(usuarioError.message)
+      setLoading(false)
       return
     }
     const { error: recursosError } = await supabase.from('recursos_usuario').insert({
@@ -30,29 +51,51 @@ export default function Register() {
     })
     if (recursosError) {
       setError(recursosError.message)
+      setLoading(false)
       return
     }
+    setLoading(false)
     navigate('/dashboard')
   }
 
   return (
-    <div className="container mt-5">
-      <h2>Registro</h2>
-      {error && <div className="alert alert-danger">{error}</div>}
-      <form onSubmit={handleSubmit} className="needs-validation" noValidate>
-        <div className="mb-3">
-          <label className="form-label">Nombre de usuario</label>
-          <input type="text" className="form-control" value={username} onChange={(e) => setUsername(e.target.value)} required />
+    <div className="auth-container">
+      <h2 className="auth-title">Registro</h2>
+      {error && <div className="auth-error">{error}</div>}
+      <form onSubmit={handleSubmit} noValidate>
+        <div className="auth-field">
+          <label>Nombre de usuario</label>
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            required
+          />
         </div>
-        <div className="mb-3">
-          <label className="form-label">Correo</label>
-          <input type="email" className="form-control" value={email} onChange={(e) => setEmail(e.target.value)} required />
+        <div className="auth-field">
+          <label>Correo</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
         </div>
-        <div className="mb-3">
-          <label className="form-label">Contraseña</label>
-          <input type="password" className="form-control" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        <div className="auth-field">
+          <label>Contraseña</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
         </div>
-        <button type="submit" className="btn btn-primary">Registrarse</button>
+        <div className="auth-actions">
+          <button type="submit" disabled={loading}>
+            {loading ? 'Registrando...' : 'Registrarse'}
+          </button>
+          <Link to="/login">Inicia sesión</Link>
+        </div>
       </form>
     </div>
   )


### PR DESCRIPTION
## Summary
- implement dark dystopic theme
- re-style login and register pages
- add validation and loading states

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68752d5fc1e083248c5ed1b5ecd6eff5