### PR TITLE
Fix register insert mapping and set white text color

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
   --color-surface: #2c2f33;
   --color-primary: #3f4147;
   --color-accent: #e91e63;
-  --color-text: #e0e0e0;
+  --color-text: #ffffff;
 
   font-family: 'Roboto', sans-serif;
   line-height: 1.5;

--- a/src/pages/Register.tsx
+++ b/src/pages/Register.tsx
@@ -31,14 +31,22 @@ export default function Register() {
     }
 
     setLoading(true)
-    const { data, error: signUpError } = await supabase.auth.signUp({ email, password })
+    const { data, error: signUpError } = await supabase.auth.signUp({
+      email,
+      password,
+    })
     if (signUpError || !data.user) {
       setError(signUpError?.message ?? 'Error registering')
       setLoading(false)
       return
     }
     const userId = data.user.id
-    const { error: usuarioError } = await supabase.from('usuarios').insert({ id: userId, nombre: username })
+    const { error: usuarioError } = await supabase.from('usuarios').insert({
+      id: userId,
+      nombre_usuario: username,
+      correo: email,
+      clave: password,
+    })
     if (usuarioError) {
       setError(usuarioError.message)
       setLoading(false)


### PR DESCRIPTION
## Summary
- fix `usuarios` insert call to use `nombre_usuario`, `correo`, and `clave`
- set text color variable to white

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js'*)

------
https://chatgpt.com/codex/tasks/task_e_68752f5581048324bebdd9e70c27f6a3