### PR TITLE
Implement Recursos module with Supabase RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,24 @@ export default tseslint.config([
 
 ## Environment Variables
 Create a .env file based on .env.example with your Supabase credentials.
+
+## Recursos Module
+
+A new section `/recursos` is available from the dashboard sidebar. It displays the current resources and the factories owned by the user. Buttons allow you to collect generated resources and start upgrades.
+
+### SQL functions
+SQL definitions for the RPC functions used by this module are in `sql/recursos_functions.sql`. Execute this file in your Supabase/PostgreSQL database to create the required procedures:
+
+```
+psql < sql/recursos_functions.sql
+```
+
+### Development
+Run the app in development mode with:
+
+```
+npm install
+npm run dev
+```
+
+Remember to configure your `.env` with your Supabase credentials.

--- a/sql/recursos_functions.sql
+++ b/sql/recursos_functions.sql
@@ -1,0 +1,129 @@
+-- SQL functions for resources module
+
+-- actualizar_recursos_generados: actualiza y devuelve los recursos generados para una fabrica
+create or replace function public.actualizar_recursos_generados(
+    p_usuario_id uuid,
+    p_tipo_recurso text
+) returns bigint
+language plpgsql
+as $$
+declare
+    v_f fabricas_usuario%rowtype;
+    v_cfg configuracion_fabricas.generacion_por_minuto%type;
+    v_generado bigint := 0;
+    v_seconds numeric;
+begin
+    select * into v_f from fabricas_usuario
+      where usuario_id = p_usuario_id and tipo_recurso = p_tipo_recurso
+      for update;
+    if not found then
+        raise exception 'Fabrica no encontrada';
+    end if;
+
+    select generacion_por_minuto into v_cfg from configuracion_fabricas
+      where tipo_recurso = p_tipo_recurso and nivel = v_f.nivel;
+
+    v_seconds := extract(epoch from (now() - v_f.ultima_recogida));
+    v_generado := floor((v_seconds / 60) * coalesce(v_cfg,0));
+
+    if v_generado > 0 then
+        execute format('update recursos_usuario set %I = %I + $1 where usuario_id = $2',
+                       p_tipo_recurso, p_tipo_recurso)
+        using v_generado, p_usuario_id;
+    end if;
+
+    update fabricas_usuario
+       set ultima_recogida = now()
+     where usuario_id = p_usuario_id and tipo_recurso = p_tipo_recurso;
+
+    return v_generado;
+end;
+$$;
+
+-- iniciar_mejora_fabrica: deduce recursos y marca inicio de mejora
+create or replace function public.iniciar_mejora_fabrica(
+    p_usuario_id uuid,
+    p_tipo_recurso text
+) returns void
+language plpgsql
+as $$
+declare
+    v_f fabricas_usuario%rowtype;
+    v_cfg mejora_fabricas_config%rowtype;
+begin
+    select * into v_f from fabricas_usuario
+      where usuario_id = p_usuario_id and tipo_recurso = p_tipo_recurso
+      for update;
+    if not found then
+        raise exception 'Fabrica no encontrada';
+    end if;
+
+    select * into v_cfg from mejora_fabricas_config
+      where tipo_recurso = p_tipo_recurso and nivel_destino = v_f.nivel + 1;
+    if not found then
+        raise exception 'No existe configuracion de mejora';
+    end if;
+
+    -- verificar recursos suficientes
+    perform 1 from recursos_usuario
+      where usuario_id = p_usuario_id
+        and chrono_polvo >= v_cfg.costo_chrono_polvo
+        and cristal_etereo >= v_cfg.costo_cristal_etereo
+        and combustible_singularidad >= v_cfg.costo_combustible_singularidad
+        and nucleos_potencia >= v_cfg.costo_nucleos_potencia
+        and creditos_galacticos >= v_cfg.costo_creditos_galacticos
+        and sustancia_x >= v_cfg.costo_sustancia_x
+      for update;
+    if not found then
+        raise exception 'Recursos insuficientes';
+    end if;
+
+    update recursos_usuario set
+        chrono_polvo = chrono_polvo - v_cfg.costo_chrono_polvo,
+        cristal_etereo = cristal_etereo - v_cfg.costo_cristal_etereo,
+        combustible_singularidad = combustible_singularidad - v_cfg.costo_combustible_singularidad,
+        nucleos_potencia = nucleos_potencia - v_cfg.costo_nucleos_potencia,
+        creditos_galacticos = creditos_galacticos - v_cfg.costo_creditos_galacticos,
+        sustancia_x = sustancia_x - v_cfg.costo_sustancia_x
+     where usuario_id = p_usuario_id;
+
+    update fabricas_usuario
+       set inicio_mejora = now()
+     where usuario_id = p_usuario_id and tipo_recurso = p_tipo_recurso;
+end;
+$$;
+
+-- completar_mejora_fabrica: finaliza la mejora si el tiempo ha transcurrido
+create or replace function public.completar_mejora_fabrica(
+    p_usuario_id uuid,
+    p_tipo_recurso text
+) returns void
+language plpgsql
+as $$
+declare
+    v_f fabricas_usuario%rowtype;
+    v_cfg mejora_fabricas_config%rowtype;
+    v_fin timestamp;
+begin
+    select * into v_f from fabricas_usuario
+      where usuario_id = p_usuario_id and tipo_recurso = p_tipo_recurso
+      for update;
+    if not found or v_f.inicio_mejora is null then
+        raise exception 'No hay mejora en curso';
+    end if;
+
+    select * into v_cfg from mejora_fabricas_config
+      where tipo_recurso = p_tipo_recurso and nivel_destino = v_f.nivel + 1;
+
+    v_fin := v_f.inicio_mejora + make_interval(secs => v_cfg.tiempo_mejora_segundos);
+    if now() < v_fin then
+        raise exception 'La mejora aun no ha terminado';
+    end if;
+
+    update fabricas_usuario
+       set nivel = nivel + 1,
+           inicio_mejora = null,
+           ultima_recogida = now()
+     where usuario_id = p_usuario_id and tipo_recurso = p_tipo_recurso;
+end;
+$$;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { AuthProvider, useAuth } from './AuthContext'
 import Login from './pages/Login'
 import Register from './pages/Register'
 import Dashboard from './pages/Dashboard'
+import RecursosModule from './pages/RecursosModule'
 import 'bootstrap/dist/css/bootstrap.min.css'
 
 function ProtectedRoute({ children }: { children: JSX.Element }) {
@@ -23,6 +24,14 @@ export default function App() {
             element={
               <ProtectedRoute>
                 <Dashboard />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/recursos"
+            element={
+              <ProtectedRoute>
+                <RecursosModule />
               </ProtectedRoute>
             }
           />

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -33,26 +33,38 @@ export default function Dashboard() {
   if (!user) return null
 
   return (
-    <div className="container mt-5">
-      <h2>Dashboard</h2>
-      {recursos ? (
-        <div className="row row-cols-1 row-cols-md-3 g-4">
-          {Object.entries(recursos).map(([key, value]) =>
-            key !== 'usuario_id' ? (
-              <div className="col" key={key}>
-                <div className="card h-100 text-center">
-                  <div className="card-body">
-                    <h5 className="card-title text-capitalize">{key.replace('_', ' ')}</h5>
-                    <p className="card-text">{value}</p>
+    <div className="d-flex">
+      <aside className="p-3 bg-dark text-white" style={{ minWidth: '200px' }}>
+        <ul className="nav flex-column">
+          <li className="nav-item">
+            <button className="btn btn-link text-start text-white" onClick={() => navigate('/dashboard')}>Inicio</button>
+          </li>
+          <li className="nav-item">
+            <button className="btn btn-link text-start text-white" onClick={() => navigate('/recursos')}>Recursos</button>
+          </li>
+        </ul>
+      </aside>
+      <main className="flex-grow-1 p-4">
+        <h2>Dashboard</h2>
+        {recursos ? (
+          <div className="row row-cols-1 row-cols-md-3 g-4">
+            {Object.entries(recursos).map(([key, value]) =>
+              key !== 'usuario_id' ? (
+                <div className="col" key={key}>
+                  <div className="card h-100 text-center">
+                    <div className="card-body">
+                      <h5 className="card-title text-capitalize">{key.replace('_', ' ')}</h5>
+                      <p className="card-text">{value}</p>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ) : null
-          )}
-        </div>
-      ) : (
-        <p>Cargando...</p>
-      )}
+              ) : null
+            )}
+          </div>
+        ) : (
+          <p>Cargando...</p>
+        )}
+      </main>
     </div>
   )
 }

--- a/src/pages/RecursosModule.tsx
+++ b/src/pages/RecursosModule.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { supabase } from '../supabaseClient'
+import { useAuth } from '../AuthContext'
+
+interface Fabrica {
+  usuario_id: string
+  tipo_recurso: string
+  nivel: number
+  ultima_recogida: string
+  inicio_mejora: string | null
+}
+
+interface GeneracionConfig {
+  tipo_recurso: string
+  nivel: number
+  generacion_por_minuto: number
+}
+
+interface MejoraConfig {
+  tipo_recurso: string
+  nivel_destino: number
+  tiempo_mejora_segundos: number
+  costo_chrono_polvo: number
+  costo_cristal_etereo: number
+  costo_combustible_singularidad: number
+  costo_nucleos_potencia: number
+  costo_creditos_galacticos: number
+  costo_sustancia_x: number
+}
+
+export default function RecursosModule() {
+  const { user } = useAuth()
+  const navigate = useNavigate()
+  const [recursos, setRecursos] = useState<Record<string, number>>({})
+  const [fabricas, setFabricas] = useState<Fabrica[]>([])
+  const [genConfig, setGenConfig] = useState<GeneracionConfig[]>([])
+  const [mejoraConfig, setMejoraConfig] = useState<MejoraConfig[]>([])
+  const [loading, setLoading] = useState(true)
+  const [modal, setModal] = useState<Fabrica | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!user) {
+      navigate('/login')
+      return
+    }
+    loadData()
+    const interval = setInterval(() => {
+      updateGenerated()
+    }, 5000)
+    return () => clearInterval(interval)
+  }, [user])
+
+  const loadData = async () => {
+    if (!user) return
+    setLoading(true)
+    const { data: rec } = await supabase
+      .from('recursos_usuario')
+      .select('*')
+      .eq('usuario_id', user.id)
+      .single()
+    setRecursos(rec || {})
+
+    const { data: fab } = await supabase
+      .from('fabricas_usuario')
+      .select('*')
+      .eq('usuario_id', user.id)
+    setFabricas(fab || [])
+
+    const { data: conf } = await supabase
+      .from('configuracion_fabricas')
+      .select('*')
+    setGenConfig(conf || [])
+
+    const { data: confM } = await supabase.from('mejora_fabricas_config').select('*')
+    setMejoraConfig(confM || [])
+
+    setLoading(false)
+  }
+
+  const getRate = (tipo: string, nivel: number) => {
+    const cfg = genConfig.find((c) => c.tipo_recurso === tipo && c.nivel === nivel)
+    return cfg?.generacion_por_minuto ?? 0
+  }
+
+  const calculateGenerated = (f: Fabrica) => {
+    const rate = getRate(f.tipo_recurso, f.nivel)
+    const seconds = (Date.now() - new Date(f.ultima_recogida).getTime()) / 1000
+    return Math.floor((seconds / 60) * rate)
+  }
+
+  const updateGenerated = () => {
+    setFabricas((prev) => [...prev])
+  }
+
+  const handleCollect = async (tipo: string) => {
+    if (!user) return
+    const { error: err } = await supabase.rpc('actualizar_recursos_generados', {
+      usuario_id: user.id,
+      tipo_recurso: tipo,
+    })
+    if (err) setError(err.message)
+    await loadData()
+  }
+
+  const timeLeft = (f: Fabrica) => {
+    if (!f.inicio_mejora) return 0
+    const cfg = mejoraConfig.find(
+      (c) => c.tipo_recurso === f.tipo_recurso && c.nivel_destino === f.nivel + 1
+    )
+    if (!cfg) return 0
+    const end = new Date(f.inicio_mejora).getTime() + cfg.tiempo_mejora_segundos * 1000
+    return Math.max(0, Math.ceil((end - Date.now()) / 1000))
+  }
+
+  const iniciarMejora = async () => {
+    if (!modal || !user) return
+    const { error: err } = await supabase.rpc('iniciar_mejora_fabrica', {
+      usuario_id: user.id,
+      tipo_recurso: modal.tipo_recurso,
+    })
+    if (err) setError(err.message)
+    setModal(null)
+    await loadData()
+  }
+
+  const completarMejora = async (f: Fabrica) => {
+    if (!user) return
+    const { error: err } = await supabase.rpc('completar_mejora_fabrica', {
+      usuario_id: user.id,
+      tipo_recurso: f.tipo_recurso,
+    })
+    if (err) setError(err.message)
+    await loadData()
+  }
+
+  if (!user) return null
+
+  return (
+    <div className="container mt-4">
+      <h2>Recursos</h2>
+      {error && <div className="alert alert-danger">{error}</div>}
+      {loading ? (
+        <p>Cargando...</p>
+      ) : (
+        <>
+          <div className="row row-cols-1 row-cols-md-3 g-4 mb-4">
+            {Object.entries(recursos).map(([k, v]) =>
+              k !== 'usuario_id' ? (
+                <div className="col" key={k}>
+                  <div className="card h-100 text-center">
+                    <div className="card-body">
+                      <h5 className="card-title text-capitalize">{k.replace('_', ' ')}</h5>
+                      <p className="card-text">{v}</p>
+                    </div>
+                  </div>
+                </div>
+              ) : null
+            )}
+          </div>
+          <table className="table table-dark table-striped">
+            <thead>
+              <tr>
+                <th>Fábrica</th>
+                <th>Nivel</th>
+                <th>Generado</th>
+                <th>Acciones</th>
+              </tr>
+            </thead>
+            <tbody>
+              {fabricas.map((f) => (
+                <tr key={f.tipo_recurso}>
+                  <td className="text-capitalize">{f.tipo_recurso.replace('_', ' ')}</td>
+                  <td>{f.nivel}</td>
+                  <td>{calculateGenerated(f)}</td>
+                  <td>
+                    <button
+                      className="btn btn-sm btn-secondary me-2"
+                      onClick={() => handleCollect(f.tipo_recurso)}
+                    >
+                      Recoger
+                    </button>
+                    {f.inicio_mejora ? (
+                      <>
+                        <span className="me-2">{timeLeft(f)}s</span>
+                        {timeLeft(f) === 0 && (
+                          <button
+                            className="btn btn-sm btn-success"
+                            onClick={() => completarMejora(f)}
+                          >
+                            Completar
+                          </button>
+                        )}
+                      </>
+                    ) : (
+                      <button
+                        className="btn btn-sm btn-primary"
+                        onClick={() => setModal(f)}
+                      >
+                        Mejorar
+                      </button>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+
+      {modal && (
+        <div className="modal d-block" tabIndex={-1} role="dialog">
+          <div className="modal-dialog" role="document">
+            <div className="modal-content text-dark">
+              <div className="modal-header">
+                <h5 className="modal-title">Mejorar {modal.tipo_recurso}</h5>
+                <button type="button" className="btn-close" onClick={() => setModal(null)}></button>
+              </div>
+              <div className="modal-body">
+                {(() => {
+                  const cfg = mejoraConfig.find(
+                    (c) =>
+                      c.tipo_recurso === modal.tipo_recurso &&
+                      c.nivel_destino === modal.nivel + 1
+                  )
+                  if (!cfg) return <p>No hay mejora disponible</p>
+                  return (
+                    <ul>
+                      <li>Nivel destino: {cfg.nivel_destino}</li>
+                      <li>Tiempo: {cfg.tiempo_mejora_segundos}s</li>
+                      <li>Costo chrono polvo: {cfg.costo_chrono_polvo}</li>
+                      <li>Costo cristal etereo: {cfg.costo_cristal_etereo}</li>
+                      <li>Costo combustible singularidad: {cfg.costo_combustible_singularidad}</li>
+                      <li>Costo nucleos potencia: {cfg.costo_nucleos_potencia}</li>
+                      <li>Costo creditos galacticos: {cfg.costo_creditos_galacticos}</li>
+                      <li>Costo sustancia x: {cfg.costo_sustancia_x}</li>
+                    </ul>
+                  )
+                })()}
+              </div>
+              <div className="modal-footer">
+                <button className="btn btn-secondary" onClick={() => setModal(null)}>
+                  Cancelar
+                </button>
+                <button className="btn btn-primary" onClick={iniciarMejora}>
+                  Iniciar Mejora
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add sidebar navigation and routing for `/recursos`
- create `RecursosModule` page to manage resources and factories
- provide SQL RPC definitions for resource operations
- document usage in README

## Testing
- `npm run lint` *(fails: cannot find packages)*

------
https://chatgpt.com/codex/tasks/task_e_6875364e354883248f94162573d6ec9f